### PR TITLE
fix clisp load error

### DIFF
--- a/default.lisp
+++ b/default.lisp
@@ -79,7 +79,7 @@
   #+allegro
   (excl::deftype-expand-1 type env)
   #+clisp
-  (ext:type-expand-1 type)
+  (ext:type-expand type t)
   #+lispworks
   (type::expand-user-type-1 type))
 


### PR DESCRIPTION
clisp (git version 057854fa1612eec8d31796d8b9128daea1f3da03) removed type-expand-1, specifying that instead of callers doing: (type-expand-1 typespec)
they were to instead do:
(type-expand typespec t)

This fix should also suit older clisps because clisp's type-expand-1 was apparently already deprecated for years before removal.